### PR TITLE
add working client/service pair examples

### DIFF
--- a/example/client_example.py
+++ b/example/client_example.py
@@ -1,7 +1,5 @@
-
 #!/usr/bin/env python
 
-from std_msgs.msg import Header
 from geometry_msgs.msg import PointStamped
 
 try:
@@ -9,7 +7,7 @@ try:
 except ImportError as e:
     print(
         '\033[33mexample_interface is not installed.',
-        'Fist install it apt-get install ros-${ROS_DISTRO}-example-interfaces. \033[0m'
+        'Fist install it apt-get install ros-${ROS_DISTRO}-example-interfaces. \033[0m',
     )
     import sys
 
@@ -17,15 +15,12 @@ except ImportError as e:
 
 from rosnodify import rosnode
 
-
 srv_name = '/two_ints'
 
+
 @rosnode.client(AddTwoInts, srv_name, timeout=1.0)
-
-
 @rosnode.publisher(PointStamped, '/param')
-
-def timer():
+def call_srv():
     a, b = 1, 2
     rosnode.logger.info("Sending request")
     request = AddTwoInts.Request(a=a, b=b)
@@ -33,15 +28,16 @@ def timer():
     rosnode.logger.warn(f"Result {result}")
     rosnode.logger.warn(f"Sum of {a} + {b} = {result.sum}")
 
+
 @rosnode.main
 def main():
     pass
 
 
-rosnode.register(node_name='test_srv', spin_once=True)
+rosnode.register(node_name='test_srv', do_spin=False)
 
 if __name__ == '__main__':
-    timer()
+    call_srv()
     import IPython
-    IPython.embed()
 
+    IPython.embed()

--- a/example/example.py
+++ b/example/example.py
@@ -1,9 +1,8 @@
 #!/usr/bin/env python
 
-from std_msgs.msg import Header
 from geometry_msgs.msg import PointStamped
-
 from rosnodify import rosnode
+from std_msgs.msg import Header
 
 
 @rosnode.parameters({'my_param': True, 'time_diff': 1e-1})

--- a/example/min_client.py
+++ b/example/min_client.py
@@ -1,0 +1,40 @@
+import sys
+
+from example_interfaces.srv import AddTwoInts
+import rclpy
+from rclpy.node import Node
+
+
+class MinimalClientAsync(Node):
+
+    def __init__(self):
+        super().__init__('minimal_client_async')
+        self.cli = self.create_client(AddTwoInts, '/two_ints')
+        while not self.cli.wait_for_service(timeout_sec=1.0):
+            self.get_logger().info('service not available, waiting again...')
+        self.req = AddTwoInts.Request()
+
+    def send_request(self, a, b):
+        self.req.a = a
+        self.req.b = b
+        self.future = self.cli.call_async(self.req)
+        rclpy.spin_until_future_complete(self, self.future)
+        return self.future.result()
+
+
+def main():
+    rclpy.init()
+
+    minimal_client = MinimalClientAsync()
+    response = minimal_client.send_request(int(sys.argv[1]), int(sys.argv[2]))
+    minimal_client.get_logger().info(
+        'Result of add_two_ints: for %d + %d = %d' %
+        (int(sys.argv[1]), int(sys.argv[2]), response.sum))
+
+    minimal_client.destroy_node()
+    rclpy.shutdown()
+
+
+if __name__ == '__main__':
+    main()
+

--- a/example/min_client.py
+++ b/example/min_client.py
@@ -1,12 +1,11 @@
 import sys
 
-from example_interfaces.srv import AddTwoInts
 import rclpy
+from example_interfaces.srv import AddTwoInts
 from rclpy.node import Node
 
 
 class MinimalClientAsync(Node):
-
     def __init__(self):
         super().__init__('minimal_client_async')
         self.cli = self.create_client(AddTwoInts, '/two_ints')
@@ -28,8 +27,8 @@ def main():
     minimal_client = MinimalClientAsync()
     response = minimal_client.send_request(int(sys.argv[1]), int(sys.argv[2]))
     minimal_client.get_logger().info(
-        'Result of add_two_ints: for %d + %d = %d' %
-        (int(sys.argv[1]), int(sys.argv[2]), response.sum))
+        'Result of add_two_ints: for %d + %d = %d' % (int(sys.argv[1]), int(sys.argv[2]), response.sum)
+    )
 
     minimal_client.destroy_node()
     rclpy.shutdown()
@@ -37,4 +36,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-

--- a/example/min_srv.py
+++ b/example/min_srv.py
@@ -1,0 +1,33 @@
+from example_interfaces.srv import AddTwoInts
+
+import rclpy
+from rclpy.node import Node
+
+
+class MinimalService(Node):
+
+    def __init__(self):
+        super().__init__('minimal_service')
+        self.srv = self.create_service(AddTwoInts, '/two_ints', self.add_two_ints_callback)
+
+    def add_two_ints_callback(self, request, response):
+        response.sum = request.a + request.b
+        self.get_logger().info('Incoming request\na: %d b: %d' % (request.a, request.b))
+        self.get_logger().info(f"Responding with response {response}")
+
+        return response
+
+
+def main():
+    rclpy.init()
+
+    minimal_service = MinimalService()
+
+    rclpy.spin(minimal_service)
+
+    rclpy.shutdown()
+
+
+if __name__ == '__main__':
+    main()
+

--- a/example/min_srv.py
+++ b/example/min_srv.py
@@ -1,11 +1,9 @@
-from example_interfaces.srv import AddTwoInts
-
 import rclpy
+from example_interfaces.srv import AddTwoInts
 from rclpy.node import Node
 
 
 class MinimalService(Node):
-
     def __init__(self):
         super().__init__('minimal_service')
         self.srv = self.create_service(AddTwoInts, '/two_ints', self.add_two_ints_callback)
@@ -30,4 +28,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-

--- a/example/srv_client.py
+++ b/example/srv_client.py
@@ -1,0 +1,47 @@
+
+#!/usr/bin/env python
+
+from std_msgs.msg import Header
+from geometry_msgs.msg import PointStamped
+
+try:
+    from example_interfaces.srv import AddTwoInts
+except ImportError as e:
+    print(
+        '\033[33mexample_interface is not installed.',
+        'Fist install it apt-get install ros-${ROS_DISTRO}-example-interfaces. \033[0m'
+    )
+    import sys
+
+    sys.exit()
+
+from rosnodify import rosnode
+
+
+srv_name = '/two_ints'
+
+@rosnode.client(AddTwoInts, srv_name, timeout=1.0)
+
+
+@rosnode.publisher(PointStamped, '/param')
+
+def timer():
+    a, b = 1, 2
+    rosnode.logger.info("Sending request")
+    request = AddTwoInts.Request(a=a, b=b)
+    result = rosnode.call_async(request, srv_name, True)
+    rosnode.logger.warn(f"Result {result}")
+    rosnode.logger.warn(f"Sum of {a} + {b} = {result.sum}")
+
+@rosnode.main
+def main():
+    pass
+
+
+rosnode.register(node_name='test_srv', spin_once=True)
+
+if __name__ == '__main__':
+    timer()
+    import IPython
+    IPython.embed()
+

--- a/example/srv_example.py
+++ b/example/srv_example.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-from std_msgs.msg import Header
 from geometry_msgs.msg import PointStamped
 
 try:
@@ -8,14 +7,13 @@ try:
 except ImportError as e:
     print(
         '\033[33mexample_interface is not installed.',
-        'Fist install it apt-get install ros-${ROS_DISTRO}-example-interfaces. \033[0m'
+        'Fist install it apt-get install ros-${ROS_DISTRO}-example-interfaces. \033[0m',
     )
     import sys
 
     sys.exit()
 
 from rosnodify import rosnode
-
 
 srv_name = '/two_ints'
 
@@ -27,8 +25,6 @@ def service(request, response):
     response.sum = request.a + request.b
     rosnode.logger.info(f"Responding with {response}")
     return response
-
-
 
 
 rosnode.register(node_name='test_srv')

--- a/example/srv_example.py
+++ b/example/srv_example.py
@@ -19,21 +19,16 @@ from rosnodify import rosnode
 
 srv_name = '/two_ints'
 
-@rosnode.client(AddTwoInts, srv_name)
+
+@rosnode.publisher(PointStamped, '/param')
 @rosnode.service(AddTwoInts, srv_name)
 def service(request, response):
+    rosnode.logger.info("Got service call")
     response.sum = request.a + request.b
+    rosnode.logger.info(f"Responding with {response}")
     return response
 
 
-@rosnode.publisher(PointStamped, '/param')
-@rosnode.timer(0.5)
-def timer():
-    a, b = 1, 2
-    request = AddTwoInts.Request(a=a, b=b)
-    result = rosnode.call_async(request, srv_name, True)
-    
-    rosnode.logger.warn(f"Sum of {a} + {b} = {result.result()}")
 
 
 rosnode.register(node_name='test_srv')

--- a/example/timer_client_srv.py
+++ b/example/timer_client_srv.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python
+
+from std_msgs.msg import Header
+from geometry_msgs.msg import PointStamped
+
+try:
+    from example_interfaces.srv import AddTwoInts
+except ImportError as e:
+    print(
+        '\033[33mexample_interface is not installed.',
+        'Fist install it apt-get install ros-${ROS_DISTRO}-example-interfaces. \033[0m'
+    )
+    import sys
+
+    sys.exit()
+
+from rosnodify import rosnode
+
+
+srv_name = '/two_ints'
+
+@rosnode.client(AddTwoInts, srv_name, timeout=1.0)
+
+
+@rosnode.publisher(PointStamped, '/param')
+@rosnode.timer(0.5)
+def timer():
+    a, b = 1, 2
+    rosnode.logger.info("Sending request")
+    request = AddTwoInts.Request(a=a, b=b)
+    rosnode.future = rosnode.call_async(request, srv_name, wait=False)
+
+
+@rosnode.main
+def main():
+    pass
+
+
+rosnode.register(node_name='test_srv', spin_once=True)
+
+import rclpy
+while rclpy.ok():
+   rclpy.spin_once(rosnode._node)
+   future = getattr(rosnode, "future", None)
+   if future.done():
+     result = future.result()
+     rosnode.logger.warn(f"Result {result}")

--- a/rosnodify/rosnodify.py
+++ b/rosnodify/rosnodify.py
@@ -329,31 +329,14 @@ class Nodify(object):
 
     def call_async(self, request, srv_name: str, wait: bool = False, timeout: float = None):
         client = self.get_client(srv_name)
-        service_avail = client.wait_for_service(timeout_sec=timeout)
-        if not service_avail:
-            print("Service not available")
-            return
-        else:
-            print("Got service, continuing")
-
         future = client.call_async(request)
-        print("Spin until future complete")
-        rclpy.spin_until_future_complete(self._node, future, timeout_sec=timeout)
-        """
-        while rclpy.ok():
-            print("Going to spin once")
-            rclpy.spin_once(self._node)
-            print("Spin once")
-            if future.done():
-                result = future.result()
-                print(result)
-        """
+        if wait:
+            rclpy.spin_until_future_complete(self._node, future, timeout_sec=timeout)
         return future.result()
 
     @exception_t(error=KeyboardInterrupt)
     def spin(self, once: bool = False):
         if once:
-            print("Spinning once")
             rclpy.spin_once(self._node)
             return
         while rclpy.ok():
@@ -389,8 +372,10 @@ class Nodify(object):
         if self._main_func:
             self._main_func()
 
+        do_spin = kwargs.get('do_spin', True)
         once = kwargs.get('spin_once', False)
-        # self.spin(once=once)
+        if do_spin:
+            self.spin(once=once)
 
     # @exception_t(error=KeyError)
     # @assert_t(obj=str)

--- a/rosnodify/rosnodify.py
+++ b/rosnodify/rosnodify.py
@@ -332,7 +332,8 @@ class Nodify(object):
         future = client.call_async(request)
         if wait:
             rclpy.spin_until_future_complete(self._node, future, timeout_sec=timeout)
-        return future.result()
+            return future.result()
+        return future
 
     @exception_t(error=KeyboardInterrupt)
     def spin(self, once: bool = False):


### PR DESCRIPTION
* add `do_spin` to node registration so that the initial spins are optional
* add working client/service pair examples (split `srv_example` into `srv_example` and `client_example`)
* add MWE client/service examples (not using rosnodify) for debugging
* add working timer-based client/service pair example